### PR TITLE
[fix] Pass the _right_ set of options to builds ctor

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,8 +48,8 @@ function Warehouse(options) {
   //
   // Special subscriber API to manage subscription lists.
   //
-  this.builds = new Builds(this, options.cache);
-  this.verifier = new Verify(this);
+  this.builds = new Warehouse.Builds(this, options.builds);
+  this.verifier = new Warehouse.Verify(this);
 }
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,8 @@
 const assume = require('assume');
+const sinon = require('sinon');
 const Warehouse = require('..');
+
+assume.use(require('assume-sinon'));
 
 describe('warehousei.ai-api-client.tests', function () {
   const wrhs = new Warehouse('https://my-warehouse-api');
@@ -16,5 +19,20 @@ describe('warehousei.ai-api-client.tests', function () {
 
   it('should have a builds prototype attached', function () {
     assume(wrhs.builds).is.instanceof(Warehouse.Builds);
+  });
+
+  it('should pass the right config to builds', function () {
+    const buildsSpy = sinon.spy(Warehouse, 'Builds');
+    const buildConfig = { foo: 'bar' };
+
+    const warehouseClient = new Warehouse({
+      uri: 'http://ImAUri',
+      builds: buildConfig,
+      nother: 'thing' });
+
+    assume(warehouseClient).is.not.null();
+    assume(buildsSpy).is.called(1);
+    assume(buildsSpy).is.calledWithNew();
+    assume(buildsSpy).is.calledWithExactly(warehouseClient, buildConfig);
   });
 });


### PR DESCRIPTION
Missed this on the refactor of my last change. *sigh*

Before:
```js
new Warehouse({ 
  uri, 
  cache: {
    cache: {
      actualCacheOptions, ...
    }
  }
});
```

After:
```js
new Warehouse({ 
  uri, 
  builds: {
    cache: {
      actualCacheOptions, ...
    }
  }
});
```