### PR TITLE
[BREAKING] Return failure reason and build ID from verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- **BREAKING:** `verify` now passes back the build ID and failure reason in addition to the URI that failed
+  - Instead of an array of URI strings, it is now an array of objects containing
+    `{ buildId: string, uri: string, reason: string}`
 - **MAJOR:** Migrate from `request` to `node-fetch`
   - Some methods in the base export accept an `options` parameter that sets request options. Since these are now passed
     through to `node-fetch` rather than `request`, there may be incompatibilities introduced. As such, this is a major

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -13,10 +13,15 @@ describe('Verify', function () {
 
   function mockRequest(opts) {
     const status = opts.statusCode;
+    const error = opts.error;
     let counter = 0;
     opts.heads.forEach(head => {
       head.recommended.forEach(() => {
-        opts.stub.onCall(counter).resolves({ status });
+        if (error) {
+          opts.stub.onCall(counter).rejects(error);
+        } else {
+          opts.stub.onCall(counter).resolves({ status });
+        }
         counter++;
       });
     });
@@ -46,7 +51,26 @@ describe('Verify', function () {
         assume(chk.buildId).contains('whatever-package!prod!');
         assume(chk).hasOwn('uri');
         assume(chk.uri).is.a('string');
-        assume(chk).hasOwn('reason', 'status 404');
+        assume(chk).hasOwn('reason', 'Received HTTP status 404');
+      });
+      done();
+    });
+  });
+
+  it('responds with a list of failed checks due to network errors', function (done) {
+    sinon.stub(wrhs.builds, 'heads').yieldsAsync(null, mocks.heads);
+    const requestStub = sinon.stub(wrhs.verifier, 'fetch');
+    const calls = mockRequest({ stub: requestStub, heads: mocks.heads, error: new Error('mock network error') });
+    wrhs.verify({ pkg: 'whatever-package', env: 'prod' }, function (err, checks) {
+      assume(err).is.falsey();
+      assume(checks).has.length(calls);
+      checks.forEach(chk => {
+        assume(chk).hasOwn('buildId');
+        assume(chk.buildId).contains('whatever-package!prod!');
+        assume(chk).hasOwn('uri');
+        assume(chk.uri).is.a('string');
+        assume(chk).hasOwn('reason');
+        assume(chk.reason).contains('mock network error');
       });
       done();
     });
@@ -60,7 +84,9 @@ describe('Verify', function () {
       assume(err).is.falsey();
       assume(checks).has.length(mocks.missingFiles.length);
       checks.forEach(chk => {
-        assume(chk).hasOwn('reason', 'Expect number of files in head 2 to equal 3');
+        assume(chk).hasOwn('reason');
+        assume(chk.reason).contains('Expect number of files in head 2 to equal 3');
+        assume(chk.reason).contains('.js'); // contains URLs that were found
       });
       done();
     });

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -41,6 +41,13 @@ describe('Verify', function () {
     wrhs.verify({ pkg: 'whatever-package', env: 'prod' }, function (err, checks) {
       assume(err).is.falsey();
       assume(checks).has.length(calls);
+      checks.forEach(chk => {
+        assume(chk).hasOwn('buildId');
+        assume(chk.buildId).contains('whatever-package!prod!');
+        assume(chk).hasOwn('uri');
+        assume(chk.uri).is.a('string');
+        assume(chk).hasOwn('reason', 'status 404');
+      });
       done();
     });
   });
@@ -52,6 +59,9 @@ describe('Verify', function () {
     wrhs.verify({ pkg: 'whatever-package', env: 'prod', numFiles: 3 }, function (err, checks) {
       assume(err).is.falsey();
       assume(checks).has.length(mocks.missingFiles.length);
+      checks.forEach(chk => {
+        assume(chk).hasOwn('reason', 'Expect number of files in head 2 to equal 3');
+      });
       done();
     });
   });

--- a/verify.js
+++ b/verify.js
@@ -22,7 +22,7 @@ class Verify {
    * @typedef {Object} VerificationFailure
    * @prop {string} [buildId] ID of build being verified
    * @prop {string} [uri] URI of file that failed
-   * @prop {string|Error} reason Reason for failure
+   * @prop {string} reason Reason for failure
    */
   /**
    * Fetches all files from one of the builds
@@ -49,7 +49,8 @@ class Verify {
     }
 
     if (numFiles) {
-      const reason = `Expect number of files in head ${urls.length} to equal ${numFiles}`;
+      let reason = `Expect number of files in head ${urls.length} to equal ${numFiles}\nFound the following files:\n`;
+      reason += urls.join('\n');
       debug(reason);
       if (numFiles > urls.length) {
         done(null, [{ reason }]);
@@ -64,7 +65,7 @@ class Verify {
         .then(res => {
           if (res.status !== 200) {
             debug(`${buildId} | Fail ${uri}: ${res.status}`);
-            return next(null, { buildId, uri, reason: `status ${res.status}` });
+            return next(null, { buildId, uri, reason: `Received HTTP status ${res.status}` });
           }
 
           debug(`${buildId} | Fetch ok ${uri}`);
@@ -72,7 +73,7 @@ class Verify {
         })
         .catch(err => {
           debug(`${buildId} | Fail ${uri}: ${err}`);
-          return next(null, { buildId, uri, reason: err });
+          return next(null, { buildId, uri, reason: err && err.toString() || 'unknown' });
         });
     }, done);
   }


### PR DESCRIPTION
## Summary

`verify` used to only give back an array of failed URIs, but not why they failed. It only outputted this in debug logging. This PR is a breaking change to pass back the URI in addition to the build ID and reason for the failure as an object.

## Changelog

Updated `CHANGELOG.md`

## Test Plan

Adjusted unit tests
